### PR TITLE
Updated helm install example to use proper security defaults

### DIFF
--- a/user-demo/deploy/welkin-user-demo/values.yaml
+++ b/user-demo/deploy/welkin-user-demo/values.yaml
@@ -19,12 +19,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: "RuntimeDefault"
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
   # runAsUser: 1000
 
 service:


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [ ] personal data beyond what is necessary for interacting with this Pull Request;
- [ ] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

When installing the demo application according to [this section](https://elastisys.io/welkin/user-guide/kubernetes-api/#deploy-user-demo) the deployment will result in a warning about it not following the `restricted` PSS. 

```
$ helm upgrade --install ...
.
.
.
W1107 13:24:08.331340  347415 warnings.go:70] would violate PodSecurity "restricted:latest": 
  allowPrivilegeEscalation != false (container "welkin-user-demo" must set securityContext.allowPrivilegeEscalation=false), 
  unrestricted capabilities (container "welkin-user-demo" must set securityContext.capabilities.drop=["ALL"]), 
  runAsNonRoot != true (pod or container "welkin-user-demo" must set securityContext.runAsNonRoot=true), 
  seccompProfile (pod or container "welkin-user-demo" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
.
.
.
```

This would solve that issue