### PR TITLE
add rule for application access after rabbitmq network policy update

### DIFF
--- a/docs/user-guide/additional-services/rabbitmq.md
+++ b/docs/user-guide/additional-services/rabbitmq.md
@@ -125,11 +125,13 @@ To expose the AMQP URL to your application, follow one of the following upstream
 - [Create a Pod that has access to the secret data through a Volume](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume)
 - [Define container environment variables using Secret data](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data)
 
-## Allow your Pods to communicate with the RabbitMQ cluster
+### Allow your Pods to communicate with the RabbitMQ cluster
 
-The RabbitMQ cluster is protected by Network Policies. To allow your application communicating with the cluster, add the following label to your Pods: `elastisys.io/rabbitmq-<cluster_name>-access: allow`
+The RabbitMQ cluster is protected by Network Policies.
 
-You can get `cluster_name` from your administrator.
+To allow your application to communicate with the RabbitMQ cluster, add the following label to your Pods: `elastisys.io/rabbitmq-${RABBITMQ_CLUSTER}-access: allow`
+
+Using the `${RABBITMQ_CLUSTER}` from before, you can also get it from your administrator
 
 ## Using a RabbitMQ Cluster
 

--- a/docs/user-guide/additional-services/rabbitmq.md
+++ b/docs/user-guide/additional-services/rabbitmq.md
@@ -125,6 +125,12 @@ To expose the AMQP URL to your application, follow one of the following upstream
 - [Create a Pod that has access to the secret data through a Volume](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume)
 - [Define container environment variables using Secret data](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data)
 
+## Allow your Pods to communicate with the RabbitMQ cluster
+
+The RabbitMQ cluster is protected by Network Policies. To allow your application communicating with the cluster, add the following label to your Pods: `elastisys.io/rabbitmq-<cluster_name>-access: allow`
+
+You can get `cluster_name` from your administrator.
+
 ## Using a RabbitMQ Cluster
 
 Best practices for using RabbitMQ in Welkin.


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [ ] personal data beyond what is necessary for interacting with this Pull Request;
- [ ] business confidential information, such as customer names.

Quality gates:

- [ ] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [ ] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

As title suggested, add instruction for application developers to use correct labels on pods to be allowed access to rabbitmq cluster.