### PR TITLE
remove opensearch derived from opendistro

### DIFF
--- a/docs/user-guide/logs.md
+++ b/docs/user-guide/logs.md
@@ -27,7 +27,7 @@ In Welkin, OpenSearch is separate from the production workload, hence it complie
 
 ## OpenSearch
 
-Raw logs in Welkin are normalized, filtered, and processed by [Fluentd](https://www.fluentd.org/) and shipped to [OpenSearch](https://opensearch.org/) for storage and analysis. OpenSearch is derived from the fully open source version of Elasticsearch called [Open Distro for Elasticsearch](https://logz.io/blog/open-distro-for-elasticsearch/).
+Raw logs in Welkin are normalized, filtered, and processed by [Fluentd](https://www.fluentd.org/) and shipped to [OpenSearch](https://opensearch.org/) for storage and analysis.
 
 OpenSearch provides a powerful, easy-to-use event monitoring and alerting system, enabling you to monitor, search and visualize your data among other things. OpenSearch Dashboards is used as a visualization and analysis interface for OpenSearch for all your logs.
 


### PR DESCRIPTION
I removed the line saying that elasticsearch -> opendistro -> opensearch. Feels abundant to mention it at this point in time.
Close this PR if you want to keep it.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
