### PR TITLE
docs: add safeguard for restricting PDBs

### DIFF
--- a/ci/vale/styles/config/vocabularies/Elastisys/accept.txt
+++ b/ci/vale/styles/config/vocabularies/Elastisys/accept.txt
@@ -198,6 +198,7 @@ exfiltrate
 impactful
 learnings
 misconfiguration
+misconfigure
 misconfigured
 mitigation
 offboarding

--- a/docs/user-guide/safeguards/enforce-restricted-pod-disruption-budgets.md
+++ b/docs/user-guide/safeguards/enforce-restricted-pod-disruption-budgets.md
@@ -1,0 +1,67 @@
+---
+search:
+  boost: 2
+---
+
+<!--
+Note to contributors: Aim for the following format.
+
+* Title: Highlight benefit to Application Developer
+* Context
+* Problem
+* Solution
+* Error
+* Resolution
+-->
+
+# Avoid Installing PodDisruptionBudgets which Prevent Maintenance and Security Patches
+
+> [!IMPORTANT]
+> This guardrail is enabled by default and will deny violations.
+> As a result, resources that violate this policy will not be created.
+
+## Problem
+
+PodDisruptionBudgets is a tool that can ensure your application does not suffer from too much disruption during normal maintenance operations.
+PodDisruptionBudgets work by limiting how many Pods in a given Deployment or other Pod controller (StatefulSet, ReplicaSet, or ReplicationController) can be evicted at the same time, when a platform administrator drains a Node.
+Platform administrators typically drain Nodes for maintenance purposes like restarting and upgrading Nodes or for removing and replacing Nodes, some of these actions might be done automatically by different tools.
+
+When configured correctly PodDisruptionBudgets can be a good tool to collaborate with your platform administrators.
+But it is possible to misconfigure them in a way that prevents or hinders platform administrators from draining Nodes.
+If you create a PodDisruptionBudget that does not allow for any disruptions, then draining Nodes with a matching Pod will fail unless the platform administrator manually kills the Pod.
+
+## Solution
+
+To solve this problem you need to ensure that all PodDisruptionBudgets allow for at least one Pod disruption at a time.
+
+- For PodDisruptionBudgets with `maxUnavailable` you need to set that option to anything above `0` or `0%`.
+- For PodDisruptionBudgets with `minAvailable` you need to set that option to anything lower than the number of replicas in the Pod controller.
+    - For percentages the `minAvailable` is rounded up to nearest integer.
+    E.g. if the number of replicas for a Deployment is `4`, then any percentage from `1%` to `25%`would evaluate to require at least 1 available replica.
+    In the same example you would then not want to set the percentage to `76%` or higher, since that would require all 4 replicas to be available, i.e. it would not allow for any Pod disruptions.
+
+## How Does Welkin Help?
+
+To make sure you don't create PodDisruptionBudgets that does not allow for Pod disruptions, the administrator can configure Welkin to deny creation of PodDisruptionBudgets and Pod controllers that does not allow for Pod disruptions.
+So you might have both PodDisruptionBudgets and Pod controllers be denied by this policy.
+
+If you get the following error:
+
+```error
+Error from server (Forbidden): error when creating "pdb.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [elastisys-restrict-pod-disruption-budgets] PodDisruptionBudget rejected: Deployment <test-deployment> has 4 replica(s) but PodDisruptionBudget <test-pdb> has minAvailable of 4, minAvailable should always be lower than replica(s), and not used when replica(s) is set to 1. Read more about this and possible solutions at <link-to-public-documentation>
+```
+
+Then your PodDisruptionBudget and Pod controller does not allow for any Pod disruption.
+
+If your administrator has not enforced this policy yet, you can view current violations of the policy by running:
+
+```bash
+kubectl get k8srestrictpoddisruptionbudgets.constraints.gatekeeper.sh elastisys-restrict-pod-disruption-budgets -ojson | jq .status.violations
+```
+
+## Further reading
+
+You can read more about Pod disruption and PodDisruptionBudgets in the upstream documentation for Kubernetes.
+
+- [Pod disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
+- [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
           - "Enforce Job TTL": "user-guide/safeguards/enforce-job-ttl.md"
           - "Enforce No LoadBalancer Service": "user-guide/safeguards/enforce-no-load-balancer-service.md"
           - "Enforce Minimum Replicas": "user-guide/safeguards/enforce-minimum-replicas.md"
+          - "Enforce Maintenance-Friendly PodDisruptionBudgets": "user-guide/safeguards/enforce-restricted-pod-disruption-budgets.md"
           - "Enforce No Local Storage EmptyDir": "user-guide/safeguards/enforce-no-local-storage-emptydir.md"
           - "Enforce No Pod Without Controller": "user-guide/safeguards/enforce-no-pod-without-controller.md"
           - "Default Pod Topology Spread Constraints": "user-guide/safeguards/default-pod-topology-spread-constraints.md"


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.

This adds documentation for a new safeguard regarding restricting the use of PodDisruptionBudgets.
The implementation is done in https://github.com/elastisys/compliantkubernetes-apps/pull/2459 
There you can find a lot more details on why and how this was implemented.
