### PR TITLE
Fix: tag not showing up in tags index page

### DIFF
--- a/mkdocs-ciso-controls/ciso_controls/__init__.py
+++ b/mkdocs-ciso-controls/ciso_controls/__init__.py
@@ -39,14 +39,14 @@ class CisoControlsPlugin(mkdocs.plugins.BasePlugin):
             log.info(f'Found tags index URL: {file.url}')
 
     def on_page_markdown(self, markdown, page, config, files):
-        if page.url.startswith(self.root_url):
-            log.info(f"Rendering tags index: {page.file.url}")
-            return self.__render_tag_index(markdown, page)
-
         # Add page to tags index
         for tag in page.meta.get("tags", []):
             tags_index = self._tag_to_tags_index(tag)
             self.tags[tags_index][tag].append(page)
+
+        if page.url.startswith(self.root_url):
+            log.info(f"Rendering tags index: {page.file.url}")
+            return self.__render_tag_index(markdown, page)
 
     def on_page_context(self, context, page, config, nav):
         # Inject tags into page (after search and before minification)

--- a/mkdocs-ciso-controls/setup.py
+++ b/mkdocs-ciso-controls/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="mkdocs-ciso-controls",
-    version="0.0.2",
+    version="0.0.3",
     author="Cristian Klein",
     author_email="cristian.klein@elastisys.com",
     description="Use tags to capture ISMS controls and group them by source.",


### PR DESCRIPTION
ISO 27001:2022 has a control which should point to GDPR. We want to capture this by assigning the GDPR page -- which is a tag index page -- the 'ISO 27001 Annex A 5.34 Privacy and Protection of PII' tag.

Due to a logic mistake, a tag on a tag index page would not be properly processed.

See https://github.com/elastisys/welkin/actions/runs/14126181416/job/39575670777#step:5:582 for even more details.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
