### PR TITLE
Prefer title from markdown

### DIFF
--- a/mkdocs-ciso-controls/ciso_controls/__init__.py
+++ b/mkdocs-ciso-controls/ciso_controls/__init__.py
@@ -100,7 +100,7 @@ class CisoControlsPlugin(mkdocs.plugins.BasePlugin):
             # Ensure forward slashes, as we have to use the path of the source
             # file which contains the operating system's path separator.
             content.append("- [{}]({})".format(
-                page.meta.get("title", page.title),
+                page._title_from_render or page.title,
                 url
             ))
 

--- a/user-demo/package-lock.json
+++ b/user-demo/package-lock.json
@@ -522,11 +522,12 @@
       }
     },
     "node_modules/cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
       "dependencies": {
-        "cookie": "0.4.0",
+        "cookie": "0.7.2",
         "cookie-signature": "1.0.6"
       },
       "engines": {
@@ -534,9 +535,10 @@
       }
     },
     "node_modules/cookie-parser/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }


### PR DESCRIPTION
Previously the CISO pages would take the title from the nav, which are purposefully short (e.g., "Troubleshooting"). Instead, take the title from the Markdown document, which are longer (e.g., "Troubleshooting for Platform Administrators").

Before:

> ISO 27001 Annex A 5.24 Information Security Incident Management Planning and Preparation
> - Troubleshooting
> - Troubleshooting

After:

> ISO 27001 Annex A 5.24 Information Security Incident Management Planning and Preparation
> - Troubleshooting for Platform Administrators
> - Troubleshooting for Application Developers

Also: Update some dependencies in the user-demo.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
