### PR TITLE
Docs: fix typos / grammar / markdown markup after proofreading

### DIFF
--- a/docs/adr/0050-use-cluster-isolation.md
+++ b/docs/adr/0050-use-cluster-isolation.md
@@ -76,7 +76,7 @@ Given the regulatory and information security landscape above, what level of iso
     - Good, because the application and observability stack can be in different Security Zones.
     - Bad, because traces end up in the same Security Zone as logs and metrics.
 1. Use Cluster isolation between application and observability stack. Host the application and its traces in one Cluster, while the other Cluster hosts logs and metrics.
-    - Good, because it avoid Cluster sprawl, i.e., only two Cluster, instead of the minimum of one.
+    - Good, because it avoids Cluster sprawl, i.e., only two Cluster, instead of the minimum of one.
     - Good, because it follows the Security Zone model.
 1. Use Cluster isolation with one Cluster for each of application, traces, logs and metrics.
     - Neutral, because, compared to the option above, it does allow more Security Zones. However, many Security Zones are likely to be of the same protection class, hence, the benefits in terms of security does not outweigh the cost.

--- a/docs/adr/0053-do-not-expose-platform-observability-services-to-end-users.md
+++ b/docs/adr/0053-do-not-expose-platform-observability-services-to-end-users.md
@@ -44,7 +44,7 @@ We will allow external clients to push observability data (logs, metrics, traces
 **Additional Considerations Note**
 In accordance with our [ToS-A5.3 As a whole, for the intended use-case](https://elastisys.com/legal/terms-of-service/#a53-as-a-whole-for-the-intended-use-case), please note the following:
 
-- It is critical to acknowledge that while these components (OpenSearch, Prometheus) are technically capable of handling external clients, our platform observability services is designed and optimized to function as a secure platform for containerized applications. Using these components in isolation or for other use-cases introduces unknown risks, and such configurations are not covered by the Self-managed Plan. Therefore, support for external clients observability data is limited to Application Developers compliance with the intended use-case of our platform observability services.
+- It is critical to acknowledge that while these components (OpenSearch, Prometheus) are technically capable of handling external clients, our platform observability services are designed and optimized to function as a secure platform for containerized applications. Using these components in isolation or for other use-cases introduces unknown risks, and such configurations are not covered by the Self-managed Plan. Therefore, support for external clients observability data is limited to Application Developers compliance with the intended use-case of our platform observability services.
 - Authentication and authorization mechanisms will be in place to ensure only trusted external clients can send observability data. Any use of these services outside of the intended platform observability scope may not be supported by the platform.
 
 **Public Clients:**

--- a/docs/operator-manual/break-glass.md
+++ b/docs/operator-manual/break-glass.md
@@ -83,26 +83,26 @@ If Dex is broken, you can manually create a `kubeconfig` file for a user. While 
 
     The kubeconfig file for `user1` user looks like:
 
-        ```yaml
-        apiVersion: v1
-        clusters:
-        - cluster:
-            certificate-authority-data: <CA>
-            server: https://control-node-ip:6443 # ip address of one of the control nodes
+    ```yaml
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: <CA>
+        server: https://control-node-ip:6443 # ip address of one of the control nodes
 
-        name: <cluster-name>
-        contexts:
-        - context:
-            cluster: <cluster-name>
-            user: user1 # <USER>
-        name: <USER>@<CLUSTER-NAME>
-        kind: Config
-        users:
-        - name: user1
-        user:
-            client-certificate-data: <CLIENT-CRT-DATA>
-            client-key-data: <CLIENT-KEY-DATA>
-        ```
+    name: <cluster-name>
+    contexts:
+    - context:
+        cluster: <cluster-name>
+        user: user1 # <USER>
+    name: <USER>@<CLUSTER-NAME>
+    kind: Config
+    users:
+    - name: user1
+    user:
+        client-certificate-data: <CLIENT-CRT-DATA>
+        client-key-data: <CLIENT-KEY-DATA>
+    ```
 
 1. Add the user and namespaces that s/he has access to in wc-config.yaml file.
 

--- a/docs/operator-manual/credentials.md
+++ b/docs/operator-manual/credentials.md
@@ -19,7 +19,7 @@ Welkin interacts with a lot of credentials. This document captures all of them i
 ## Single Sign-On (SSO) Credentials
 
 - Example: Company Google Accounts
-- Purpose: authenticate a person with various system, in particular
+- Purpose: authenticate a person with various systems, in particular
     - Kubernetes API via Dex
     - Grafana via Dex
     - OpenSearch Dashboards via Dex

--- a/docs/operator-manual/maintenance.md
+++ b/docs/operator-manual/maintenance.md
@@ -36,7 +36,7 @@ Let's go through them one by one.
 
 ### Patching the Nodes
 
-Security patches for the underlying OS on the Nodes is constantly being released, and to ensure your environment is secured, the Nodes that run Welkin must be updated with these patches.
+Security patches for the underlying OS on the Nodes are constantly being released, and to ensure your environment is secured, the Nodes that run Welkin must be updated with these patches.
 We recommend that you use the [AutomaticSecurityUpdates](https://help.ubuntu.com/community/AutomaticSecurityUpdates) feature that is available in Ubuntu (similar feature exist in other Linux distributions) to install these updates.
 Note that the Nodes still need to be rebooted for some of these updates to be applied.
 In order to reboot the Nodes, you can either use a tool like [kured](https://github.com/kubereboot/kured) or you can do it manually by logging on to the Nodes and rebooting them manually.
@@ -52,7 +52,7 @@ It will cordon and reboot the Nodes one by one.
 ### Upgrading the Welkin application stack
 
 Welkin consists of a multitude of open source components that interact to form a smooth End User experience.
-In order to free you of the burden of keeping track of when to upgrade the various components, new versions of Welkin are regularly release.
+In order to free you of the burden of keeping track of when to upgrade the various components, new versions of Welkin are regularly released.
 When a new version is released, it becomes available as a [tagged release](https://github.com/elastisys/compliantkubernetes-apps/tags) in the GitHub repository.
 
 > Before upgrading to a new release, please review the [changelog](https://github.com/elastisys/compliantkubernetes-apps/tree/main/changelog) if possible, apply the upgrade to a staging environment before upgrading any environments with production data.
@@ -119,10 +119,10 @@ Then check the release notes for each version in between to see if there are any
 1. Verify that everything is running after the upgrade.
     At the minimum, at least run the tests in compliantkubernetes-apps.
 
-        ```bash
-        ./bin/ck8s test sc
-        ./bin/ck8s test wc
-        ```
+    ```bash
+    ./bin/ck8s test sc
+    ./bin/ck8s test wc
+    ```
 
 1. Go back to step 1 and repeat one new release of compliantkubernetes-apps at a time until you are at the latest release.
 

--- a/docs/operator-manual/on-prem-standard.md
+++ b/docs/operator-manual/on-prem-standard.md
@@ -101,8 +101,8 @@ This document contains instructions on how to set-up a new Welkin on-prem enviro
     === "For Docker"
 
         ``` markdown
-        * For Management Cluster: Added `docker_options: "--default-address-pool base=10.179.0.0/24,size=24"` in `${CK8S_CONFIG_PATH}/sc-config/group_vars/all/docker.yml` file.
-        * For Workload Cluster:  Added `docker_options: "--default-address-pool base=10.179.4.0/24,size=24"` in `${CK8S_CONFIG_PATH}/wc-config/group_vars/all/docker.yml` file.
+        * For Management Cluster: Add `docker_options: "--default-address-pool base=10.179.0.0/24,size=24"` in `${CK8S_CONFIG_PATH}/sc-config/group_vars/all/docker.yml` file.
+        * For Workload Cluster:  Add `docker_options: "--default-address-pool base=10.179.4.0/24,size=24"` in `${CK8S_CONFIG_PATH}/wc-config/group_vars/all/docker.yml` file.
         ```
 
 ### Init Kubespray configuration in your configuration path

--- a/docs/operator-manual/provider-audit.md
+++ b/docs/operator-manual/provider-audit.md
@@ -86,7 +86,7 @@ The remainder of this page contains open questions that you should ask your Infr
         1. Do you have immutable storage or object lock?
         1. Is OSaaS stretched across zones?
         1. Is object storage replicated across zones?
-    1. Do you offer Block storage as a Service (BLaaS)?
+    1. Do you offer Block storage as a Service (BSaaS)?
         1. Which API (OpenStack, VMware)?
         1. In which zones?
         1. Can I use a [Container Storage Interface (CSI) driver](https://kubernetes-csi.github.io/docs/drivers.html) for automatic creating of PersistentVolumes?

--- a/docs/operator-manual/understand-welkin.md
+++ b/docs/operator-manual/understand-welkin.md
@@ -112,14 +112,14 @@ Let us dive into the role of each of these files in the order you would commonly
 
 - `README.md` is a human description of the environment.
 This file is optional and ignored by Welkin.
-We recommend describing here the propose of the Environment, what kind of applications it hosts, what infrastructure provider it runs on and any noteworthy deviations.
+We recommend describing here the purpose of the Environment, what kind of applications it hosts, what infrastructure provider it runs on and any noteworthy deviations.
 - `adminlogs` is a folder where you can put text files (Markdown) describing operations you performed against this environment.
 This folder is optional and ignored by Welkin.
 We recommend having separate folders for changes, incidents and maintenance.
 - `.sops.yaml` contains [sops](https://github.com/getsops/sops) configuration, used by Welkin to encrypt secrets.
 Welkin makes sure to decrypt secrets when it needs them.
 - `ck8s-cluster-api`, `compliantkubernetes-apps` and `compliantkubernetes-kubespray` are the git submodules of the Cluster API, Apps and Kubespray layer, respectively.
-These contains the command-line tools to operate Welkin.
+These contain the command-line tools to operate Welkin.
 
 The Welkin Kubespray layer initializes and reads the following configuration files and folders:
 
@@ -127,7 +127,7 @@ The Welkin Kubespray layer initializes and reads the following configuration fil
 These folders are consumed by Ansible, which is part of this layer.
 If `group_vars`, `all` and `inventory.ini` look new to you, we recommend you [learn more about Ansible](understand-the-basics.md).
 
-The Welkin Cluster API layer initialized and reads the following configuration files and folders:
+The Welkin Cluster API layer initializes and reads the following configuration files and folders:
 
 - `capi/defaults` is a folder which contains the default `capi/values.yaml` for the infrastructure provider and flavor you chose when you initialized the configuration repository using Welkin.
 Do not change these files, as they may be overridden by Welkin.
@@ -158,7 +158,7 @@ The following files and folders are stored by Welkin in the configuration reposi
 
 - `.state` is a folder which contains the "state", i.e., files produced by Welkin needed to access an Environment during daily operations, in particular kubeconfig and S3 object storage access.
 Typically, these files should be encrypted with sops for information security purposes.
-In Welkin, kubeconfigs generally don't contain credentials, only pointer to OpenID configuration, hence are usually not encrypted.
+In Welkin, kubeconfigs generally don't contain credentials, only pointers to OpenID configuration, hence are usually not encrypted.
 
 To make sure your whole team knows exactly which version of Welkin an Environment runs, it is common practice to add the source code, in the example above `compliantkubernetes-apps` and `compliantkubernetes-kubespray`, as git submodules.
 An alternative is to pack all Welkin source code in a Docker image.
@@ -178,7 +178,7 @@ To make it easy to get started, Welkin supports several default configurations d
 
 You must specify a configuration repository in the environment variable `CK8S_CONFIG_PATH`.
 Then you can interact with Welkin via commands such as `ck8s` and `ck8s-kubespray` provided in the source code.
-A typical usage of these commands is describe later in this guide.
+A typical usage of these commands is described later in this guide.
 
 ## Next Steps
 


### PR DESCRIPTION
Addresses mishaps spotted during proofreading and
also acts as a proof *of* reading:

- singular/plural mismatches
- missing 'd' in past tense
- missing 's' in present tense, 3rd person
- remove extra indentation from code blocks that resulted in extra "```language" lines being rendered
- BLaaS -> BSaaS

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
