### PR TITLE
Remove pre-branding URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,11 +71,11 @@ jobs:
           if [ "$GITHUB_REF_NAME" == "main" ]; then
               # Latest version of the docs goes under https://elastisys.io/welkin
               VERSION_TITLE="main"
-              VERSION="welkin compliantkubernetes ck8s"
+              VERSION="welkin"
           else
               # Other versions go under https://elastisys.io/welkin-v0.42/
               VERSION_TITLE=$(echo "$GITHUB_REF_NAME" | cut -d- -f2)
-              VERSION="welkin-${VERSION_TITLE} compliantkubernetes-${VERSION_TITLE}"
+              VERSION="welkin-${VERSION_TITLE}"
           fi
           echo version: $VERSION version-title: $VERSION_TITLE
           mike deploy $VERSION -t $VERSION_TITLE --push --template overrides/redirect.html --alias-type redirect


### PR DESCRIPTION
We rebranded from ck8s and compliantkubernetes to Welkin 6 months ago. Time to remove those old URLs.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
