### PR TITLE
docs: some clarifications on the velero restore section

### DIFF
--- a/docs/operator-manual/disaster-recovery.md
+++ b/docs/operator-manual/disaster-recovery.md
@@ -352,9 +352,6 @@ Instructions for how to restore Harbor can be found in `compliantkubernetes-apps
 These instructions focuses on backups for the Workload Cluster using the Velero CLI.
 For instructions on using Velero in the Management Cluster see the [Grafana section](#grafana).
 
-> [!NOTE]
-> The steps for running Velero in this document assumes `v0.39` or later of Welkin, as the Velero CLI is now part of the `ck8s ops` CLI making it easier to operate on both Clusters with Velero without having to manually set `KUBECONFIG`, as long as `CK8S_CONFIG_PATH` points to the correct environment.
-
 Read more about Velero [here](../user-guide/backup.md).
 
 > [!NOTE]
@@ -394,14 +391,20 @@ Restoring from a backup with Velero is meant to be a type of disaster recovery.
 **Velero will not overwrite existing Resources when restoring.**
 As such, if you want to restore the state of a Resource that is still running, the Resource must be deleted first.
 
-If you want to restore the entire Cluster, all you need to run to restore the state from the latest daily backup, is:
+The default daily Velero backup in the Workload Cluster is used to backup everything in application developer namespaces and the Alertmanager configuration secret.
+If you want to restore the entire Workload Cluster, first you should delete the Alertmanager secret in WC, then all you need to run to restore the state from the latest daily backup is:
 
 ```bash
-./bin/ck8s ops velero sc restore create --from-schedule velero-daily-backup --wait
+# Delete the alertmanager secret so that it can be restored from backup
+./bin/ck8s ops kubectl wc delete secret -n alertmanager alertmanager-kube-prometheus-stack-alertmanager
 # Make sure application dependencies like Harbor, Postgres, RabbitMQ
 # and Redis are restored/installed before restoring wc with velero.
-./bin/ck8s ops velero wc restore create --from-schedule velero-daily-backup --wait
+# If this environment has managed ArgoCD, then that should be restored later.
+./bin/ck8s ops velero wc restore create --from-schedule velero-daily-backup --exclude-namespaces argocd-system --wait
 ```
+
+Velero in the Management Cluster is used to backup user Grafana.
+See the section `Grafana` further down on this page for instructions on how to restore that.
 
 > [!TIP]
 > Use `./bin/ck8s ops velero wc restore create --help` to see available flags and some examples.


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.

Some clarifications for the velero disaster recovery documentation. I also removed a note for an old version of Welkin.