### PR TITLE
removed hnc plugin instructions and replaced with yaml

### DIFF
--- a/docs/user-guide/namespaces.md
+++ b/docs/user-guide/namespaces.md
@@ -52,22 +52,6 @@ status:
 
 If the status is `Ok` then the subnamespace is ready to go.
 
-!!!tip
-
-    HNC also comes with the [HNS `kubectl` plugin](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#prepare-to-use-hierarchical-namespaces-as-a-user).
-
-    Using this plugin creating subnamespaces is as easy as:
-    ```bash
-    kubectl hns create -n <parent-namespace> <descendant-namespace>
-    ```
-
-    And provides more detailed information using:
-    ```bash
-    kubectl hns describe <namespace>
-
-    kubectl hns tree <namespace>
-    ```
-
 If you decide a subnamespace is no longer needed, then you can't delete it using `kubectl delete namespace <descendant-namespace>`. As you will get the following error:
 
 > Error from server (Forbidden): namespaces `<descendant-namespace>` is forbidden: User `<your user>` cannot delete resource "namespaces" in API group "" in the namespace `<descendant-namespace>`: RBAC: [clusterrole.rbac.authorization.k8s.io "user-crds" not found, clusterrole.rbac.authorization.k8s.io "user-crds-resourcename-limit" not found]
@@ -76,8 +60,6 @@ Instead you will have to delete it using either of these commands:
 
 ```bash
 kubectl delete subns -n <parent-namespace> <descendant-namespace>
-# or
-kubectl hns delete -n <parent-namespace> <descendant-namespace> # with the plugin installed
 ```
 
 ## Resource Propagation

--- a/docs/user-guide/self-managed-services/flux.md
+++ b/docs/user-guide/self-managed-services/flux.md
@@ -69,9 +69,17 @@ kubectl apply -k crds
 
 #### Namespace
 
-You need to create a namespace where Flux will work. This namespace must be called `flux-system`. Create this [sub-namespace](../namespaces.md) under e.g. `production`.
+You need to create a namespace where Flux will work. This namespace must be called `flux-system`. Create this [sub-namespace](../namespaces.md) under your parent namespace, e.g. `production`.
 
-`kubectl hns create -n production flux-system`
+```bash
+kubectl apply -f - <<EOF
+apiVersion: hnc.x-k8s.io/v1alpha2
+kind: SubnamespaceAnchor
+metadata:
+  name: flux-system
+  namespace: production
+EOF
+```
 
 #### Git Secret
 

--- a/docs/user-guide/self-managed-services/kafka.md
+++ b/docs/user-guide/self-managed-services/kafka.md
@@ -59,9 +59,17 @@ kubectl apply -f crds/kafka-crds.yaml
 
 ### Namespace
 
-You need to create a namespace where Strimzi Kafka Operator will work. This namespace must be called `kafka`. Create this [sub-namespace](../namespaces.md) under e.g. `production`.
+You need to create a namespace where Strimzi Kafka Operator will work. This namespace must be called `kafka`. Create this [sub-namespace](../namespaces.md) under your parent namespace, e.g. `production`.
 
-`kubectl hns create -n production kafka`
+```bash
+kubectl apply -f - <<EOF
+apiVersion: hnc.x-k8s.io/v1alpha2
+kind: SubnamespaceAnchor
+metadata:
+  name: kafka
+  namespace: production
+EOF
+```
 
 ### Roles and RoleBindings
 


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.


---

Since HNC plugin can no longer be installed with krew. I've removed the instructions for how to create and remove sub-namespaces with the plugin and replaced with instructions with yaml instead.