### PR TITLE
Fix postgres docs for creating an application user

### DIFF
--- a/docs/user-guide/additional-services/postgresql.md
+++ b/docs/user-guide/additional-services/postgresql.md
@@ -122,7 +122,7 @@ cat <<EOF | psql -d postgres -h 127.0.0.1 -U $PGUSER \
     --set=APP_USERNAME=$APP_USERNAME \
     --set=APP_PASSWORD=$APP_PASSWORD
 create database :APP_DATABASE;
-create user :APP_USERNAME with encrypted password ':APP_PASSWORD';
+create user :APP_USERNAME with encrypted password :'APP_PASSWORD';
 grant all privileges on database :APP_DATABASE to :APP_USERNAME;
 EOF
 ```


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.

The postgres docs for creating a new database and user was not working, the password for the user would become `:APP_PASSWORD`. This fixes that so that the actual password is used.