### PR TITLE
docs: change references to rook repository

### DIFF
--- a/docs/operator-manual/common.md
+++ b/docs/operator-manual/common.md
@@ -4,6 +4,9 @@
 
 ### Deploy Rook
 
+!!! welkin-enterprise "For Welkin Enterprise Customers"
+    To get access to the `welkin-rook` repository, [contact Elastisys](https://elastisys.com/contact/).
+
 To deploy Rook, go to the `welkin-rook` repository and follow the instructions [here](https://github.com/elastisys/welkin-rook/blob/main/README.md) for each Cluster.
 
 > [!NOTE]

--- a/docs/operator-manual/common.md
+++ b/docs/operator-manual/common.md
@@ -4,7 +4,7 @@
 
 ### Deploy Rook
 
-To deploy Rook, go to the `compliantkubernetes-kubespray` repository, change directory to `rook` and follow the instructions [here](https://github.com/elastisys/compliantkubernetes-kubespray/tree/main/rook#rook-ceph) for each Cluster.
+To deploy Rook, go to the `welkin-rook` repository and follow the instructions [here](https://github.com/elastisys/welkin-rook/blob/main/README.md) for each Cluster.
 
 > [!NOTE]
 > If the kubeconfig files for the Clusters are encrypted with SOPS, you need to decrypt them before using them:


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.

Changed a reference to the rook folder in `compliantkubernetes-kubespray` repo to point to the new `welkin-rook` repo instead.