### PR TITLE
Call jsonschema2md directly

### DIFF
--- a/scripts/jsonschema2md.sh
+++ b/scripts/jsonschema2md.sh
@@ -171,7 +171,11 @@ yq --output-format json ".\"\$id\" = \"https://raw.githubusercontent.com/elastis
 log.trace "converted schema"
 
 pushd "${root}" &>/dev/null || log.error "failed to change directory"
-npx jsonschema2md -d "${temp}" -f yaml -o "${staging}" -x "${staging}/json"
+if command -v jsonschema2md >/dev/null 2>&1; then
+  jsonschema2md -d "${temp}" -f yaml -o "${staging}" -x "${staging}/json"
+else
+  npx jsonschema2md -d "${temp}" -f yaml -o "${staging}" -x "${staging}/json"
+fi
 popd &>/dev/null || log.error "failed to change directory"
 
 log.trace "generated documentation"


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.

We're moving the Apps repository to handle npm dependencies through `package.json / package-lock.json`, so now the `jsonschema2md` should be available as a binary and in path in our test docker images, negating the need for `npx` indirection.
