### PR TITLE
feat: Help robots avoid superseded pages

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -67,6 +67,13 @@ if(!document.__defineGetter__) {
 <link rel="shortcut icon" href="/welkin/img/favicon.ico" />
 <link rel="apple-touch-icon" sizes="180x180" href="/welkin/img/apple-touch-icon.png" />
 <link rel="manifest" href="/welkin/img/site.webmanifest" />
+
+{% if page and page.meta and page.meta.robots %}
+  <meta name="robots" content="{{ page.meta.robots }}">
+{% elif page and "Superseded" in page.title %}
+  <!-- Help robots avoid superseded pages -->
+  <meta name="robots" content="noindex">
+{% endif %}
 {% endblock %}
 
 <!--


### PR DESCRIPTION
It seems like robots (e.g., Google Search) struggle to understand that some of our pages are superseded. This leads to bad search results and also inaccurate information in Gemini.

This PR helps robots avoid superseded pages.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.