### PR TITLE
chore(config reference): Make permalinks more obvious

### DIFF
--- a/scripts/jsonschema2md.py
+++ b/scripts/jsonschema2md.py
@@ -53,7 +53,10 @@ def render_path(path):
 
     label = re.sub(r'([./_-])', r'\1<wbr>', path)
 
-    return f'<a id="{anchor}"></a>[{label}](#{anchor})'
+    return (
+        f'{label}' +
+        f'<a id="{anchor}" class="headerlink" href="#{anchor}" title="Permanent link">¶</a>'
+    )
 
 @dataclass
 class Counters:


### PR DESCRIPTION
Previously the whole configuration key was a link, which raised the expectation that clicking on it would lead somewhere. Use the permalink marker to make it more obvious that these are just links to the configuration key itself.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
