### PR TITLE
chore(linkchecker): Fix links to Ubuntu manpages

### DIFF
--- a/docs/operator-manual/air-gapped.md
+++ b/docs/operator-manual/air-gapped.md
@@ -364,7 +364,7 @@ To successfully run in an air-gapped environment, Welkin and the underlying oper
 - All servers in the air-gapped environment MUST be configured to:
     - use the NTP system above (see [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html));
     - use the DNS system above (see [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html));
-    - trust your Certificate Authority (see [update-ca-certificates](https://manpages.ubuntu.com/manpages/xenial/man8/update-ca-certificates.8.html));
+    - trust your Certificate Authority (see [update-ca-certificates](https://manpages.ubuntu.com/manpages/noble/en/man8/update-ca-certificates.8.html));
     - use the file server for OS repositories;
     - use the registry mirror for container images (see description above).
 - Welkin MUST be configured to:
@@ -372,7 +372,7 @@ To successfully run in an air-gapped environment, Welkin and the underlying oper
     - use the identity provider above.
 - Containers MUST trust your Certificate Authority. This can be accomplished as follows:
     - Note: Currently, Welkin **only supports Option A**. Please contact Elastisys, if you prefer Option B or C.
-    - Option A: Build containers so as to trust your Certificate Authority (see [update-ca-certificates](https://manpages.ubuntu.com/manpages/xenial/man8/update-ca-certificates.8.html)).
+    - Option A: Build containers so as to trust your Certificate Authority (see [update-ca-certificates](https://manpages.ubuntu.com/manpages/noble/en/man8/update-ca-certificates.8.html)).
         - This solution solves the trust problem at build-time. Some people see this as the most robust, as it can be more robustly tested and rolled out.
     - Option B: Inject the certificate of your Certificate Authority with [trust-manager](https://cert-manager.io/docs/trust/trust-manager/).
     - Option C: Inject the certificate of your Certificate Authority with [Kyverno](https://kyverno.io/policies/other/add-certificates-volume/add-certificates-volume/).

--- a/docs/operator-manual/getting-started.md
+++ b/docs/operator-manual/getting-started.md
@@ -10,7 +10,7 @@ In theory, any vanilla Kubernetes Cluster can be used for Welkin. We suggest the
 - [Python3 pip](https://packaging.python.org/en/latest/guides/installing-using-linux-tools/)
 - [Terraform](https://developer.hashicorp.com/terraform/downloads)
 - [Ansible](https://www.ansible.com/)
-- [`pwgen`](https://manpages.ubuntu.com/manpages/trusty/man1/pwgen.1.html)
+- [`pwgen`](https://manpages.ubuntu.com/manpages/noble/en/man1/pwgen.1.html)
 
 Ansible is best installed as follows:
 


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

> [!IMPORTANT]
> Links to code snippets reference line numbers.
> If you changed the [NodeJS user demo](../user-demo/) or the [DotNET user demo](../user-demo-dotnet/), then please search for all links to code snippets and update them accordingly.
> You can find such links with `egrep -R '\[.*\]\(.*user-demo.*#L.*)' docs`.

- [x] I have updated links to code snippets or I haven't changed code snippets.
